### PR TITLE
Updated to work properly with sqlsrv driver.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -230,7 +230,7 @@ class SqlServerGrammar extends Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s.000';
+        return 'Y-m-d H:i:s+';
     }
 
     /**


### PR DESCRIPTION
Updated to work properly with sqlsrv driver.  Carbon was throwing an error:

[2015-10-21 03:17:07] local.ERROR: exception 'InvalidArgumentException' with message 'Unexpected data found.
Unexpected data found.
The separation symbol could not be found
The format separator does not match
Trailing data' in /Users/xxxxx/Sites/xxxxx/vendor/nesbot/carbon/src/Carbon/Carbon.php:414
Stack trace:
#0 /Users/xxxxx/Sites/xxxxx/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2925): Carbon\Carbon::createFromFormat('Y-m-d H:i:s.000', 'Mar 13 2012 12:...')
